### PR TITLE
Fix registered field on getSubmissionInfo()

### DIFF
--- a/contracts/ProofOfHumanity.sol
+++ b/contracts/ProofOfHumanity.sol
@@ -1028,7 +1028,7 @@ contract ProofOfHumanity is IArbitrable, IEvidence {
      */
     function isRegistered(address _submissionID) external view returns (bool) {
         Submission storage submission = submissions[_submissionID];
-        return submission.registered && now - submission.submissionTime <= submissionDuration;
+        return _safeIsRegistered(submission);
     }
 
     /** @dev Get the number of times the arbitrator data was updated.
@@ -1091,7 +1091,7 @@ contract ProofOfHumanity is IArbitrable, IEvidence {
             submission.status,
             submission.submissionTime,
             submission.index,
-            submission.registered,
+            _safeIsRegistered(submission),
             submission.hasVouched,
             submission.requests.length
         );
@@ -1198,5 +1198,9 @@ contract ProofOfHumanity is IArbitrable, IEvidence {
             round.sideFunded,
             round.feeRewards
         );
+    }
+
+    function _safeIsRegistered(Submission submissionInfo) internal view returns (bool) {
+        return submission.registered && now - submission.submissionTime <= submissionDuration;
     }
 }


### PR DESCRIPTION
`isRegistered(submissionId)` relies on the `submission.registered` flag and the submission expiration as well to return the value.

`getSubmissionInfo(submissionId)` only returns the actual value of the registered field, without considering the expiration. This is not critical, but it could be a potential issue for implementors that rely on `getSubmissionInfo().registered` to validate a user on the registry.

This PR implements a solution to that issue.

Description
--

This issue was original discovered while playing around on the Kovan contract which has a submissionDuration of 4 days, where as the mainnet contract has a duration of 1 year.

This makes it impossible to test on mainnet since the contract was deployed less than a year ago, so there are not expired submissions yet.

- **For testing on [Kovan PoH contract](https://kovan.etherscan.io/address/0x73bcce92806bce146102c44c4d9c3b9b9d745794#readContract)** use this address which has that specific issue: 0x71814b57a7Cfb635B91B48F24ED6315937fF1ee3

How to reproduce:
--
Execute isRegistered(0x71814b57a7Cfb635B91B48F24ED6315937fF1ee3) and getSubmissionInfo(0x71814b57a7Cfb635B91B48F24ED6315937fF1ee3) and compare the values.